### PR TITLE
refactor: 冗長な rehype-slug を削除し MDX の非推奨警告を解消

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,6 @@ import sitemap from '@astrojs/sitemap';
 import compress from '@playform/compress';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'astro/config';
-import rehypeSlug from 'rehype-slug';
 
 export default defineConfig({
   alias: { '@': './src' },
@@ -24,7 +23,6 @@ export default defineConfig({
     sitemap(),
     compress(),
     mdx({
-      rehypePlugins: [rehypeSlug],
       components: {
         OGPCard: './src/components/articles/OGPCard.astro',
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
         "@astrojs/mdx": "^7.0.0",
         "@playform/compress": "^0.2.0",
         "@tailwindcss/vite": "^4.2.2",
-        "open-graph-scraper": "^6.11.0",
-        "rehype-slug": "^6.0.0"
+        "open-graph-scraper": "^6.11.0"
       },
       "devDependencies": {
         "@astrojs/rss": "^4.0.18",
@@ -4719,19 +4718,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/hast-util-heading-rank": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
-      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -4874,19 +4860,6 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-to-string": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
-      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7661,23 +7634,6 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/rehype-slug": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
-      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "github-slugger": "^2.0.0",
-        "hast-util-heading-rank": "^3.0.0",
-        "hast-util-to-string": "^3.0.0",
-        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@astrojs/mdx": "^7.0.0",
     "@playform/compress": "^0.2.0",
     "@tailwindcss/vite": "^4.2.2",
-    "open-graph-scraper": "^6.11.0",
-    "rehype-slug": "^6.0.0"
+    "open-graph-scraper": "^6.11.0"
   }
 }


### PR DESCRIPTION
## 概要

`@astrojs/mdx` v7 で `rehypePlugins` の直接指定が非推奨（将来のメジャーで削除予定）になった件の対応です。

> ⚠️ このPRは #8（Astro 7 移行）に依存するスタックPRです。base を `chore/dependency-updates-astro7` に設定しています。#8 マージ後に自動で main へ再ターゲットされます。

## 対応方針

当初は `markdown.processor`（`@astrojs/markdown-remark`）への移行を検討しましたが、調査の結果 **`rehype-slug` が生成する見出し ID は Astro 7 組み込みの `rehypeHeadingIds` と完全に一致し、冗長**であることが判明しました。そのためプラグインごと削除します（誤移行のリスクもなく、設定も簡素化）。

## 変更内容
- `astro.config.mjs`: `rehypePlugins: [rehypeSlug]` と `import rehypeSlug` を削除
- `package.json`: 未使用となった `rehype-slug` を依存から削除

## 検証（TOC 非回帰）
- 削除前後で**全記事の見出し ID 20件がバイト単位で完全一致**することを実証（`diff` で差分ゼロ）
- `npm run check-all`: build ✓ / lint ✓ / test 38件全パス
- `@astrojs/mdx` の `rehypePlugins` 非推奨警告が**消失**したことを確認