### PR TITLE
chore: GitHub Actions を Node.js 24 対応版へ更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -34,7 +34,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./dist
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 概要

GitHub Actions ランナーでの Node.js 20 非推奨警告を解消するため、各アクションを Node.js 24 対応の最新メジャーバージョンへ更新しました。

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4, actions/upload-artifact@v4, actions/deploy-pages@v4

## 変更内容

| アクション | 変更前 | 変更後 |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-node | v4 | v5 |
| actions/upload-pages-artifact | v3 | v4 |
| actions/deploy-pages | v4 | v5 |

## 補足

- 警告に出ていた `actions/upload-artifact@v4` はワークフローに直接記述されておらず、`upload-pages-artifact@v3` が内部で呼び出していたもの。`upload-pages-artifact@v4` へ更新することで内部の `upload-artifact` も v5（Node.js 24）に更新され、警告が解消する。
- `node-version: '22'` はビルドに使う Node のバージョン指定であり、アクション実行環境（警告対象）とは別物のため変更なし。