### PR TITLE
refactor: レガシーコンテンツコレクションを Content Layer API へ移行

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,11 +109,11 @@ src/
 
 ## Astro 7 Migration Notes
 
-When working with content collections in Astro 7 (legacy collections mode via `legacy.collectionsBackwardsCompat`):
+When working with content collections in Astro 7 (Content Layer API with `glob()` loaders):
 - Use `getCollection('articles')` instead of deprecated `getEntry()`
-- Use `entry.id` instead of `entry.slug`
+- Use `entry.id` instead of `entry.slug` — entry IDs are slug-based (e.g. `20240101-slug`), so `entry.id` IS the slug
 - Use `render(entry)` function instead of `entry.render()` method
-- Use the `getEntrySlug(id)` utility from `@/lib/content/utils` to extract slugs from entry IDs
+- The `getEntrySlug(id)` utility from `@/lib/content/utils` extracts slugs from file paths (used by fs-based loading in `files.ts`); it is not needed for Collection entries
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,11 @@ Astro 7 static site with TypeScript, Tailwind CSS 4, and MDX. Deployed to GitHub
 
 ### Astro 7 Specifics
 
-- Legacy content collections are in use (`legacy.collectionsBackwardsCompat: true` in `astro.config.mjs`). `content.config.ts` uses `type: 'content'`, and entry IDs are path-based
+- Content Layer API with `glob()` loaders (`src/content.config.ts`). Entry IDs are slug-based (e.g. `20240101-slug`), so `entry.id` IS the slug
 - Use `getCollection('articles')` (not deprecated `getEntry()`)
 - Use `entry.id` (not `entry.slug`)
 - Use `render(entry)` function (not `entry.render()` method)
-- Use `getEntrySlug(id)` from `@/lib/content/utils` to extract slugs from entry IDs
+- `getEntrySlug()` from `@/lib/content/utils` is for extracting slugs from file paths (fs-based loading in `files.ts`), not needed for Collection entries
 
 ## Code Style
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,9 +12,6 @@ export default defineConfig({
   build: {
     inlineStylesheets: 'auto',
   },
-  legacy: {
-    collectionsBackwardsCompat: true,
-  },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,8 +1,16 @@
 import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
 import { z } from 'astro/zod';
 
+// `_` 始まりのファイル・ディレクトリを除外する（レガシーコレクションと同じ挙動）
+const contentPattern = [
+  '**/*.{md,mdx}',
+  '!**/_*/**/*.{md,mdx}',
+  '!**/_*.{md,mdx}',
+];
+
 const pagesCollection = defineCollection({
-  type: 'content',
+  loader: glob({ pattern: contentPattern, base: './src/content/pages' }),
   schema: z.object({
     title: z.string(),
     summary: z.string(),
@@ -12,7 +20,10 @@ const pagesCollection = defineCollection({
 });
 
 const articlesCollection = defineCollection({
-  type: 'content',
+  loader: glob({
+    pattern: contentPattern,
+    base: './src/content/articles',
+  }),
   schema: ({ image }) =>
     z.object({
       title: z.string(),

--- a/src/content/articles/20200501-linux/index.mdx
+++ b/src/content/articles/20200501-linux/index.mdx
@@ -2,7 +2,6 @@
 title: "linux始めた"
 published_at: 2020-05-01
 updated_at: 2020-05-01
-cover_image: ""
 ---
 
 

--- a/src/lib/__tests__/schema.test.ts
+++ b/src/lib/__tests__/schema.test.ts
@@ -12,7 +12,7 @@ import {
 // Article 型のモックデータを作成するヘルパー関数
 const createMockArticle = (overrides: Partial<Article> = {}): Article => {
   const defaultArticle: Article = {
-    id: '20240101-test-article/index.mdx',
+    id: '20240101-test-article',
     collection: 'articles',
     body: '## Test',
     permalink: '/articles/20240101-test-article',

--- a/src/lib/content/__tests__/articles.test.ts
+++ b/src/lib/content/__tests__/articles.test.ts
@@ -6,7 +6,7 @@ const createArticleMock = (
   published_at: string,
   permalink: string,
 ): Article => ({
-  id: `${slug}/index.mdx`,
+  id: slug,
   collection: 'articles',
   body: '## Test Content',
   permalink,
@@ -35,9 +35,9 @@ describe('getRelatedArticles', async () => {
     const related = getRelatedArticles(target, articles, 3);
 
     expect(related.map((a) => a.id)).toEqual([
-      'a/index.mdx', // 4 days away
-      'c/index.mdx', // 5 days away
-      'd/index.mdx', // 15 days away
+      'a', // 4 days away
+      'c', // 5 days away
+      'd', // 15 days away
     ]);
   });
 

--- a/src/lib/content/files.ts
+++ b/src/lib/content/files.ts
@@ -19,6 +19,10 @@ export type ArticleFile = {
  * すべての記事ファイル (.md / .mdx) を fs から直接読み込みます。
  * Astro の Content Collection を経由できない箇所
  * (生 Markdown 配信エンドポイント・ルート列挙スクリプト)で使用します。
+ *
+ * 注意: ここで得る slug は生のディレクトリ名で、Collection 側 (glob ローダー)
+ * は githubSlug() 適用後の値になる。ディレクトリ名を小文字英数字とハイフン・
+ * アンダースコアに限定する `npm run new:article` の生成規則により一致が保たれる。
  * @returns 記事ファイル情報の配列。
  */
 export async function loadArticleFiles(): Promise<ArticleFile[]> {

--- a/src/lib/content/transform.ts
+++ b/src/lib/content/transform.ts
@@ -1,17 +1,17 @@
 // エントリをArticleオブジェクトに変換するユーティリティ関数
 import type { CollectionEntry } from 'astro:content';
 import type { Article } from '@/lib/content/types';
-import { buildPermalink, getEntrySlug } from './utils';
+import { buildPermalink } from './utils';
 
 /**
  * エントリをArticleオブジェクトに変換
+ * Content Layer の entry.id は slug そのもの（例: `20240101-slug`）
  * @param entry Astro Content Collection エントリ
  * @returns Article オブジェクト
  */
 export function transformEntryToArticle(
   entry: CollectionEntry<'articles'>,
 ): Article {
-  const slug = getEntrySlug(entry.id);
-  const permalink = buildPermalink(slug, entry.data.permalink);
+  const permalink = buildPermalink(entry.id, entry.data.permalink);
   return { ...entry, permalink };
 }

--- a/src/lib/content/utils.ts
+++ b/src/lib/content/utils.ts
@@ -1,11 +1,12 @@
 /**
- * Astro 6のentry.idからslugを抽出します。
- * Astro 6 では entry.id にコレクション名は含まれません。
+ * 記事ファイルのパスからslugを抽出します。
+ * fs 直読み（files.ts）でファイルパスを slug に変換する用途で使用します。
+ * Content Layer の entry.id は slug そのものなので、Collection 経由では不要です。
  * - `YYYYMMDD-slug/index.mdx` → `YYYYMMDD-slug`
  * - `YYYYMMDD-slug/index.md` → `YYYYMMDD-slug`
  * - `YYYYMMDD-slug.mdx` → `YYYYMMDD-slug`
  * - `YYYYMMDD-slug.md` → `YYYYMMDD-slug`
- * @param id コンテンツエントリのID
+ * @param id 記事ファイルのパス（またはレガシー形式のエントリID）
  * @returns slug文字列
  */
 export function getEntrySlug(id: string): string {

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,6 +1,6 @@
 import type { Crumb } from '@/components/Breadcrumb.astro';
 import type { Article } from '@/lib/content/types';
-import { getEntrySlug, resolveCoverImagePath } from '@/lib/content/utils';
+import { resolveCoverImagePath } from '@/lib/content/utils';
 import type { SiteConfig } from '@/site.config';
 
 export const createWebSiteSchema = (config: SiteConfig) => {
@@ -45,7 +45,7 @@ export const createArticleSchema = (
   const { title, summary, cover_image, published_at, updated_at } =
     article.data;
   const coverSrc = cover_image
-    ? resolveCoverImagePath(cover_image, getEntrySlug(article.id))
+    ? resolveCoverImagePath(cover_image, article.id)
     : undefined;
   const articleUrl = new URL(article.permalink, siteUrl).href;
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,9 +6,7 @@ import { HOME_LABEL } from '@/lib/constants';
 import { createBreadcrumbSchema } from '@/lib/schema';
 
 const pages = await getCollection('pages');
-const aboutEntry = pages.find(
-  (entry) => entry.id.startsWith('about') && !entry.id.includes('/'),
-);
+const aboutEntry = pages.find((entry) => entry.id === 'about');
 
 if (!aboutEntry) {
   throw new Error('About page content not found.');

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -10,11 +10,7 @@ import { HOME_LABEL } from '@/lib/constants';
 import { getAllArticles, getRelatedArticles } from '@/lib/content/articles';
 import { isArticleVisible } from '@/lib/content/filters';
 import type { Article } from '@/lib/content/types';
-import {
-  formatDate,
-  getEntrySlug,
-  resolveCoverImagePath,
-} from '@/lib/content/utils';
+import { formatDate, resolveCoverImagePath } from '@/lib/content/utils';
 import { createArticleSchema, createBreadcrumbSchema } from '@/lib/schema';
 import { siteConfig } from '@/site.config';
 
@@ -25,13 +21,10 @@ export async function getStaticPaths() {
     ? allArticles.filter(({ data }) => isArticleVisible(data))
     : allArticles;
 
-  return articlesToBuild.map((currentArticle) => {
-    const articleSlug = getEntrySlug(currentArticle.id);
-    return {
-      params: { slug: articleSlug },
-      props: { article: currentArticle, allArticles: articlesToBuild },
-    };
-  });
+  return articlesToBuild.map((currentArticle) => ({
+    params: { slug: currentArticle.id },
+    props: { article: currentArticle, allArticles: articlesToBuild },
+  }));
 }
 
 interface Props {
@@ -41,7 +34,7 @@ interface Props {
 
 const { article, allArticles } = Astro.props;
 const { data } = article;
-const slug = getEntrySlug(article.id);
+const slug = article.id;
 
 const { title, summary, meta_title, meta_description, cover_image } = data;
 


### PR DESCRIPTION
## 概要

Astro 7 標準の Content Layer API（`glob()` ローダー）へ移行し、`legacy.collectionsBackwardsCompat` フラグを削除。将来のメジャーバージョンで削除されるレガシー API への依存を解消する。

## 変更内容

- `content.config.ts`: `type: 'content'` → `glob()` ローダー。パターンはレガシーの `_` 始まりファイル・ディレクトリ除外を否定パターン（`!**/_*/**` 等）で完全再現
- `astro.config.mjs`: legacy ブロック削除
- entry.id が slug ベース（`20240101-slug`）になったため、`getEntrySlug(entry.id)` の間接参照を全廃（transform.ts / [slug].astro / schema.ts / about.astro）。`getEntrySlug` は fs 直読み（files.ts）のファイルパス用として存続
- `cover_image: \"\"`（image() スキーマを素通りする空文字列）を記事から削除
- files.ts に Collection 側（githubSlug 適用）との slug 一致が `new:article` の生成規則で担保される旨をコメント化
- テストモック id・CLAUDE.md / AGENTS.md を新実態に同期

## 検証

- `npm run clean` 後の `npm run check-all`: 0 errors / 0 warnings / 0 hints、テスト 47 件全パス
- **移行前後で `dist/` のルート一覧が完全一致、サンプル記事の JSON-LD がバイト単位で一致**、canonical 同一
- review-changes による第三者レビュー実施（glob パターンのディレクトリ除外漏れを検出・修正済み）